### PR TITLE
Add MQTT ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 
 MeshDump collects telemetry from Meshtastic nodes and exposes the data through
-a small web interface. Nodes are polled at regular intervals and their
-telemetry history is kept in memory. From the browser you can choose which node
+a small web interface. Nodes can be polled over HTTP or data can be ingested
+directly from an MQTT broker. The telemetry history is kept in memory and can
+optionally be persisted to a file. From the browser you can choose which node
 to inspect and view line charts of the available data types.
 
 
@@ -13,6 +14,11 @@ self-contained Windows binary while development and builds occur on Linux.
 Set the environment variable `NODES` to a comma separated list of node IP
 addresses before running the binary so the application knows which nodes to
 poll.
+To subscribe to an MQTT broker instead, set `MQTT_BROKER` to the broker URL and
+optionally `MQTT_TOPIC` (defaults to `telemetry/#`).
+
+If `DATA_FILE` is specified, telemetry is also saved to that path and reloaded
+on startup so historical data is preserved across restarts.
 
 ## Building
 

--- a/cmd/meshdump/main.go
+++ b/cmd/meshdump/main.go
@@ -18,11 +18,23 @@ func main() {
 		nodes = strings.Split(nodesEnv, ",")
 	}
 
-	store := meshdump.NewStore()
+	dataFile := os.Getenv("DATA_FILE")
+	store := meshdump.NewStore(dataFile)
 	server := meshdump.NewServer(store)
+
+	mqttBroker := os.Getenv("MQTT_BROKER")
+	mqttTopic := os.Getenv("MQTT_TOPIC")
+	if mqttTopic == "" {
+		mqttTopic = "telemetry/#"
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	if mqttBroker != "" {
+		if err := meshdump.StartMQTT(ctx, mqttBroker, mqttTopic, store); err != nil {
+			log.Fatalf("mqtt: %v", err)
+		}
+	}
 	if len(nodes) > 0 {
 		go meshdump.PollNodes(ctx, time.Minute, store, nodes)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module meshdump
 
 go 1.20
+
+require (
+    github.com/eclipse/paho.mqtt.golang v1.3.5
+)

--- a/internal/meshdump/mqtt.go
+++ b/internal/meshdump/mqtt.go
@@ -1,0 +1,38 @@
+package meshdump
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// StartMQTT connects to the given broker and subscribes to the provided topic.
+// Messages are expected to contain a JSON encoded Telemetry struct. Received
+// telemetry is stored in the provided Store until the context is cancelled.
+func StartMQTT(ctx context.Context, broker, topic string, store *Store) error {
+	opts := mqtt.NewClientOptions().AddBroker(broker)
+	client := mqtt.NewClient(opts)
+	if t := client.Connect(); t.Wait() && t.Error() != nil {
+		return t.Error()
+	}
+
+	if t := client.Subscribe(topic, 0, func(c mqtt.Client, m mqtt.Message) {
+		var tel Telemetry
+		if err := json.Unmarshal(m.Payload(), &tel); err != nil {
+			log.Printf("mqtt decode: %v", err)
+			return
+		}
+		store.Add(tel)
+	}); t.Wait() && t.Error() != nil {
+		client.Disconnect(250)
+		return t.Error()
+	}
+
+	go func() {
+		<-ctx.Done()
+		client.Disconnect(250)
+	}()
+	return nil
+}


### PR DESCRIPTION
## Summary
- support persisting telemetry data on disk
- load telemetry on startup using optional DATA_FILE env
- connect to MQTT broker via new StartMQTT function
- mention new env vars in README
- update go.mod with mqtt dependency

## Testing
- `go vet ./...` *(fails: missing go.sum entry)*
- `go build ./cmd/meshdump` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_6874d45537cc83238c24a0ec9fc10af7