### PR TITLE
Add .env loading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ can be enabled by setting `NODES` to a comma separated list of IP addresses.
 If `DATA_FILE` is specified, telemetry is also saved to that path and reloaded
 on startup so historical data is preserved across restarts.
 
-MeshDump automatically loads environment variables from a `.env` file in the
-current directory if present, so you can place the above settings there for
-convenience.
+MeshDump automatically loads environment variables from a `.env` file. It first
+looks in the current working directory and then in the directory containing the
+executable. This lets you keep the configuration next to the binary when
+running it outside of the source tree.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ can be enabled by setting `NODES` to a comma separated list of IP addresses.
 If `DATA_FILE` is specified, telemetry is also saved to that path and reloaded
 on startup so historical data is preserved across restarts.
 
+MeshDump automatically loads environment variables from a `.env` file in the
+current directory if present, so you can place the above settings there for
+convenience.
+
 ## Building
 
 Run `./build.sh` on a Linux machine with Docker installed. The script compiles

--- a/cmd/meshdump/main.go
+++ b/cmd/meshdump/main.go
@@ -11,7 +11,31 @@ import (
 	"meshdump/internal/meshdump"
 )
 
+func loadEnv(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		kv := strings.SplitN(line, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		val := strings.TrimSpace(kv[1])
+		if strings.HasPrefix(val, "\"") && strings.HasSuffix(val, "\"") && len(val) >= 2 {
+			val = strings.Trim(val, "\"")
+		}
+		os.Setenv(key, val)
+	}
+}
+
 func main() {
+	loadEnv(".env")
 	nodesEnv := os.Getenv("NODES")
 	var nodes []string
 	if nodesEnv != "" {

--- a/cmd/meshdump/main.go
+++ b/cmd/meshdump/main.go
@@ -5,15 +5,31 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"meshdump/internal/meshdump"
 )
 
-func loadEnv(path string) {
-	data, err := os.ReadFile(path)
-	if err != nil {
+func loadEnv() {
+	var paths []string
+	// first try the working directory
+	paths = append(paths, ".env")
+	// also try alongside the executable
+	if exe, err := os.Executable(); err == nil {
+		paths = append(paths, filepath.Join(filepath.Dir(exe), ".env"))
+	}
+
+	var data []byte
+	for _, p := range paths {
+		d, err := os.ReadFile(p)
+		if err == nil {
+			data = d
+			break
+		}
+	}
+	if len(data) == 0 {
 		return
 	}
 	for _, line := range strings.Split(string(data), "\n") {
@@ -35,7 +51,7 @@ func loadEnv(path string) {
 }
 
 func main() {
-	loadEnv(".env")
+	loadEnv()
 	nodesEnv := os.Getenv("NODES")
 	var nodes []string
 	if nodesEnv != "" {


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file automatically
- document the `.env` support

## Testing
- `go build ./cmd/meshdump`

------
https://chatgpt.com/codex/tasks/task_e_68750decd1dc8323b4f436b4f616a7f0