### PR TITLE
Implement SQLite storage with node info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Nodes appear in the interface as soon as they publish telemetry, so you do not
 need to list them ahead of time. HTTP polling of nodes is only for testing and
 can be enabled by setting `NODES` to a comma separated list of IP addresses.
 
-If `DATA_FILE` is specified, telemetry is also saved to that path and reloaded
-on startup so historical data is preserved across restarts.
+If `DATA_FILE` is specified, telemetry and node metadata are stored in a small
+SQLite database at that path. The file is created automatically and reloaded on
+startup so historical data is preserved across restarts.
 
 
 MeshDump automatically loads environment variables from a `.env` file. It first

--- a/internal/meshdump/server.go
+++ b/internal/meshdump/server.go
@@ -24,6 +24,7 @@ func (s *Server) Router() *http.ServeMux { return s.mux }
 func (s *Server) routes() {
 	s.mux.HandleFunc("/api/telemetry/", s.handleTelemetry())
 	s.mux.HandleFunc("/api/nodes", s.handleNodes)
+	s.mux.HandleFunc("/api/nodeinfo/", s.handleNodeInfo())
 	s.mux.HandleFunc("/", s.handleIndex)
 }
 
@@ -44,6 +45,39 @@ func (s *Server) handleNodes(w http.ResponseWriter, r *http.Request) {
 	nodes := s.store.Nodes()
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(nodes)
+}
+
+func (s *Server) handleNodeInfo() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, "/api/nodeinfo/")
+		if id == "" {
+			http.Error(w, "missing node id", http.StatusBadRequest)
+			return
+		}
+		switch r.Method {
+		case http.MethodPost:
+			var info NodeInfo
+			if err := json.NewDecoder(r.Body).Decode(&info); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if info.ID == "" {
+				info.ID = id
+			}
+			s.store.SetNodeInfo(info)
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			info, ok := s.store.Node(id)
+			w.Header().Set("Content-Type", "application/json")
+			if !ok {
+				w.Write([]byte("{}"))
+				return
+			}
+			json.NewEncoder(w).Encode(info)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
 }
 
 //go:embed web/index.html

--- a/internal/meshdump/store.go
+++ b/internal/meshdump/store.go
@@ -2,8 +2,9 @@ package meshdump
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
-	"os"
+	"os/exec"
 	"sync"
 	"time"
 )
@@ -15,36 +16,54 @@ type Telemetry struct {
 	Timestamp time.Time
 }
 
-type Store struct {
-	mu   sync.Mutex
-	data map[string][]Telemetry
-	file string
+// NodeInfo describes a node by ID with optional names.
+type NodeInfo struct {
+	ID        string
+	LongName  string
+	ShortName string
 }
 
+// Store keeps telemetry and node information in memory and persists it to an
+// optional SQLite database using the `sqlite3` command line utility.
+type Store struct {
+	mu    sync.Mutex
+	data  map[string][]Telemetry
+	nodes map[string]NodeInfo
+	file  string
+}
+
+// NewStore initializes the store. When path is non-empty a SQLite database is
+// created (if necessary) and used for persistence.
 func NewStore(path string) *Store {
-	s := &Store{data: make(map[string][]Telemetry), file: path}
+	s := &Store{data: make(map[string][]Telemetry), nodes: make(map[string]NodeInfo), file: path}
 	if path != "" {
+		_ = s.initDB()
 		_ = s.load()
 	}
 	return s
 }
 
+// Add stores a telemetry entry in memory and on disk.
 func (s *Store) Add(t Telemetry) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	log.Printf("store: add node=%s type=%s value=%f", t.NodeID, t.DataType, t.Value)
 	s.data[t.NodeID] = append(s.data[t.NodeID], t)
 	if s.file != "" {
-		_ = s.saveLocked()
+		ts := t.Timestamp.Format(time.RFC3339Nano)
+		sql := fmt.Sprintf("INSERT INTO telemetry (node_id, data_type, value, timestamp) VALUES (%q,%q,%f,%q);", t.NodeID, t.DataType, t.Value, ts)
+		_ = exec.Command("sqlite3", s.file, sql).Run()
 	}
 }
 
+// Get returns telemetry for the given node ID.
 func (s *Store) Get(nodeID string) []Telemetry {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]Telemetry(nil), s.data[nodeID]...)
 }
 
+// All returns a copy of the telemetry map.
 func (s *Store) All() map[string][]Telemetry {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -55,33 +74,94 @@ func (s *Store) All() map[string][]Telemetry {
 	return out
 }
 
-func (s *Store) Nodes() []string {
+// Nodes returns the list of known nodes with associated metadata.
+func (s *Store) Nodes() []NodeInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	nodes := make([]string, 0, len(s.data))
-	for k := range s.data {
-		nodes = append(nodes, k)
+	out := make([]NodeInfo, 0, len(s.nodes))
+	for _, n := range s.nodes {
+		out = append(out, n)
 	}
-	return nodes
+	return out
 }
 
-func (s *Store) saveLocked() error {
-	b, err := json.MarshalIndent(s.data, "", "  ")
-	if err != nil {
-		return err
+// SetNodeInfo stores metadata about a node.
+func (s *Store) SetNodeInfo(info NodeInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodes[info.ID] = info
+	if s.file != "" {
+		sql := fmt.Sprintf("INSERT OR REPLACE INTO nodes (node_id, long_name, short_name) VALUES (%q,%q,%q);", info.ID, info.LongName, info.ShortName)
+		_ = exec.Command("sqlite3", s.file, sql).Run()
 	}
-	return os.WriteFile(s.file, b, 0644)
 }
 
+// Node retrieves metadata for the given node ID. If not present, the returned
+// boolean is false.
+func (s *Store) Node(id string) (NodeInfo, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n, ok := s.nodes[id]
+	return n, ok
+}
+
+// initDB creates the required tables if they do not exist.
+func (s *Store) initDB() error {
+	schema := `CREATE TABLE IF NOT EXISTS telemetry (
+    node_id TEXT,
+    data_type TEXT,
+    value REAL,
+    timestamp TEXT
+);
+CREATE TABLE IF NOT EXISTS nodes (
+    node_id TEXT PRIMARY KEY,
+    long_name TEXT,
+    short_name TEXT
+);`
+	return exec.Command("sqlite3", s.file, schema).Run()
+}
+
+// load repopulates the in-memory store from the SQLite database.
 func (s *Store) load() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	b, err := os.ReadFile(s.file)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
+	if s.file == "" {
+		return nil
 	}
-	return json.Unmarshal(b, &s.data)
+	// load nodes
+	out, err := exec.Command("sqlite3", "-json", s.file, "SELECT node_id, long_name, short_name FROM nodes;").Output()
+	if err == nil && len(out) > 0 {
+		var rows []struct {
+			ID        string `json:"node_id"`
+			LongName  string `json:"long_name"`
+			ShortName string `json:"short_name"`
+		}
+		if err := json.Unmarshal(out, &rows); err == nil {
+			for _, r := range rows {
+				s.nodes[r.ID] = NodeInfo{ID: r.ID, LongName: r.LongName, ShortName: r.ShortName}
+			}
+		}
+	}
+	// load telemetry
+	out, err = exec.Command("sqlite3", "-json", s.file, "SELECT node_id, data_type, value, timestamp FROM telemetry;").Output()
+	if err == nil && len(out) > 0 {
+		var rows []struct {
+			NodeID    string  `json:"node_id"`
+			DataType  string  `json:"data_type"`
+			Value     float64 `json:"value"`
+			Timestamp string  `json:"timestamp"`
+		}
+		if err := json.Unmarshal(out, &rows); err == nil {
+			for _, r := range rows {
+				ts, _ := time.Parse(time.RFC3339Nano, r.Timestamp)
+				s.data[r.NodeID] = append(s.data[r.NodeID], Telemetry{
+					NodeID:    r.NodeID,
+					DataType:  r.DataType,
+					Value:     r.Value,
+					Timestamp: ts,
+				})
+			}
+		}
+	}
+	return nil
 }

--- a/internal/meshdump/web/index.html
+++ b/internal/meshdump/web/index.html
@@ -6,6 +6,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body { font-family: sans-serif; margin: 20px; }
+        #nodeSelect { min-width: 200px; padding: 4px; font-size: 14px; }
     </style>
 </head>
 <body>
@@ -52,12 +53,13 @@ async function init() {
     const nodes = await fetchNodes();
     for (const n of nodes) {
         const opt = document.createElement('option');
-        opt.value = opt.textContent = n;
+        opt.value = n.ID;
+        opt.textContent = n.LongName || n.ShortName || n.ID;
         select.appendChild(opt);
     }
     select.addEventListener('change', refresh);
     if (nodes.length) {
-        select.value = nodes[0];
+        select.value = nodes[0].ID;
         refresh();
         setInterval(refresh, 30000);
     }


### PR DESCRIPTION
## Summary
- expand store with SQLite persistence via the `sqlite3` command line
- track node metadata (long and short name)
- expose new `/api/nodeinfo/` endpoint
- widen node selection box in the UI and display node names
- document new SQLite functionality

## Testing
- `go build ./cmd/meshdump`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687579e3386c832395f78664fc720387