### PR TITLE
Fix telemetry endpoint

### DIFF
--- a/internal/meshdump/fetch.go
+++ b/internal/meshdump/fetch.go
@@ -1,17 +1,19 @@
 package meshdump
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
 
 // FetchTelemetry retrieves telemetry data from a remote Meshtastic node.
-// This is a minimal placeholder implementation that expects the node to
-// expose JSON telemetry at /api/telemetry.
+// According to the Meshtastic HTTP API documentation, nodes expose
+// telemetry at the `/api/v1/telemetry` endpoint.
 func FetchTelemetry(host string) ([]Telemetry, error) {
-	url := fmt.Sprintf("http://%s/api/telemetry", host)
+	url := fmt.Sprintf("http://%s/api/v1/telemetry", host)
 	client := http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
@@ -19,9 +21,18 @@ func FetchTelemetry(host string) ([]Telemetry, error) {
 	}
 	defer resp.Body.Close()
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, bytes.TrimSpace(body))
+	}
+
 	var data []Telemetry
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("decode telemetry: %v: %s", err, bytes.TrimSpace(body))
 	}
 	return data, nil
 }


### PR DESCRIPTION
## Summary
- update documentation comment to reference `/api/v1/telemetry`
- fetch telemetry using the `/api/v1/telemetry` path
- handle errors reading the response body

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68757fbcd3f88323bc008c52d9666119