### PR TITLE
Fix Go version for Docker build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Building Windows binary using Docker..."
-docker run --rm -v "$PWD":/src -w /src golang:1.20 \
+docker run --rm -v "$PWD":/src -w /src golang:1.23 \
     sh -c 'go mod tidy && \
     GOOS=windows GOARCH=amd64 go build -buildvcs=false -o MeshDump.exe ./cmd/meshdump'
 


### PR DESCRIPTION
## Summary
- update the Docker image used in `build.sh` so the Go toolchain supports the `toolchain` directive in `go.mod`

## Testing
- `bash build.sh` *(fails: docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_68759d64e6d88323b7503e05d8e44ee6