### PR TITLE
Update env and docs for SQLite

### DIFF
--- a/.env
+++ b/.env
@@ -12,8 +12,9 @@ MQTT_PASSWORD=secret
 MQTT_TOPIC=#
 
 
-# Optional path to persist telemetry history.
-DATA_FILE=./telemetry.json
+# Optional path to persist telemetry history in an SQLite database.
+# Using a `.db` extension makes it clear a SQLite file is expected.
+DATA_FILE=./telemetry.db
 
 # Enable extra logging when set to 1
 DEBUG=0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 MeshDump collects telemetry from Meshtastic nodes and exposes the data through
 a small web interface. Data is typically ingested from an MQTT broker and the
-telemetry history is kept in memory. It can optionally be persisted to a file.
+telemetry history is kept in memory. It can optionally be persisted to a SQLite
+database file.
 
 The program uses the Eclipse Paho MQTT client library to connect to a broker
 and subscribe to telemetry topics. Incoming messages can be JSON encoded
@@ -24,8 +25,9 @@ Nodes appear in the interface as soon as they publish telemetry, so you do not
 need to list them ahead of time.
 
 If `DATA_FILE` is specified, telemetry and node metadata are stored in a small
-SQLite database at that path. The file is created automatically and reloaded on
-startup so historical data is preserved across restarts.
+SQLite database at that path (for example `telemetry.db`). The file is created
+automatically and reloaded on startup so historical data is preserved across
+restarts.
 Node metadata now includes the firmware version when available.
 
 Set `DEBUG=1` to print additional information, including the list of nodes and


### PR DESCRIPTION
## Summary
- document SQLite data file in README
- update example env file to use `telemetry.db`

## Testing
- `go build ./...` *(fails: "encoding/hex" imported and not used)*
- `go vet ./...` *(fails: "encoding/hex" imported and not used)*

------
https://chatgpt.com/codex/tasks/task_e_6876079e3cb08323a7a2920cbb04eb95