### PR TITLE
Add unit tests for store and server

### DIFF
--- a/internal/meshdump/mqtt.go
+++ b/internal/meshdump/mqtt.go
@@ -2,17 +2,15 @@ package meshdump
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"log"
 	"strings"
 	"time"
-  
-  pproto "meshdump/internal/proto"
+
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	meshtastic "github.com/meshtastic/go/generated"
 	"google.golang.org/protobuf/proto"
-
+	pproto "meshdump/internal/proto"
 )
 
 // StartMQTT connects to the given broker and subscribes to the provided topic.
@@ -35,7 +33,6 @@ func StartMQTT(ctx context.Context, broker, topic, user, pass string, store *Sto
 	// send a welcome message to verify connectivity
 	client.Publish("meshdump/welcome", 0, false, []byte("MeshDump connected"))
 
-	debug := store.debug
 	if t := client.Subscribe(topic, 0, func(c mqtt.Client, m mqtt.Message) {
 
 		var tel Telemetry

--- a/internal/meshdump/server_test.go
+++ b/internal/meshdump/server_test.go
@@ -1,0 +1,102 @@
+package meshdump
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newTestServer() (*Server, *Store) {
+	st := NewStore("")
+	srv := NewServer(st)
+	return srv, st
+}
+
+func TestTelemetryHandler(t *testing.T) {
+	srv, st := newTestServer()
+	tel := Telemetry{NodeID: "n1", DataType: "temperature", Value: 10, Timestamp: time.Unix(1700000001, 0)}
+	st.Add(tel)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/telemetry/n1", nil)
+	srv.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var got []Telemetry
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0].NodeID != tel.NodeID ||
+		got[0].DataType != tel.DataType ||
+		got[0].Value != tel.Value ||
+		!got[0].Timestamp.Equal(tel.Timestamp) {
+		t.Errorf("unexpected body: %v", got)
+	}
+
+	// missing node
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/telemetry/", nil)
+	srv.Router().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing node, got %d", rr.Code)
+	}
+}
+
+func TestNodesHandler(t *testing.T) {
+	srv, st := newTestServer()
+	st.Add(exampleTelemetry)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/nodes", nil)
+	srv.Router().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var nodes []NodeInfo
+	if err := json.Unmarshal(rr.Body.Bytes(), &nodes); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].ID != exampleTelemetry.NodeID {
+		t.Errorf("unexpected nodes: %v", nodes)
+	}
+}
+
+func TestNodeInfoHandler(t *testing.T) {
+	srv, st := newTestServer()
+	st.Add(exampleTelemetry)
+
+	// POST update node info
+	info := NodeInfo{LongName: "Tester", Firmware: "2.0"}
+	body, _ := json.Marshal(info)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/nodeinfo/"+exampleTelemetry.NodeID, bytes.NewReader(body))
+	srv.Router().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rr.Code)
+	}
+
+	stored, ok := st.Node(exampleTelemetry.NodeID)
+	if !ok || stored.LongName != "Tester" || stored.Firmware != "2.0" {
+		t.Errorf("node info not stored: %+v", stored)
+	}
+
+	// GET existing node info
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/nodeinfo/"+exampleTelemetry.NodeID, nil)
+	srv.Router().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var got NodeInfo
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID != exampleTelemetry.NodeID || got.LongName != "Tester" {
+		t.Errorf("unexpected node info: %+v", got)
+	}
+}

--- a/internal/meshdump/store_test.go
+++ b/internal/meshdump/store_test.go
@@ -1,0 +1,52 @@
+package meshdump
+
+import (
+	"testing"
+	"time"
+)
+
+var exampleTelemetry = Telemetry{
+	NodeID:    "node1",
+	DataType:  "temperature",
+	Value:     42.5,
+	Timestamp: time.Unix(1700000000, 0),
+}
+
+func TestStoreAddGet(t *testing.T) {
+	s := NewStore("")
+	s.Add(exampleTelemetry)
+
+	got := s.Get(exampleTelemetry.NodeID)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0].NodeID != exampleTelemetry.NodeID ||
+		got[0].DataType != exampleTelemetry.DataType ||
+		got[0].Value != exampleTelemetry.Value ||
+		!got[0].Timestamp.Equal(exampleTelemetry.Timestamp) {
+		t.Errorf("unexpected telemetry: %+v", got[0])
+	}
+
+	if _, ok := s.Node(exampleTelemetry.NodeID); !ok {
+		t.Errorf("node info should be created on Add")
+	}
+}
+
+func TestStoreSetNodeInfo(t *testing.T) {
+	s := NewStore("")
+	info := NodeInfo{ID: "node2", LongName: "Node Two", ShortName: "n2", Firmware: "1.0"}
+	s.SetNodeInfo(info)
+
+	got, ok := s.Node("node2")
+	if !ok {
+		t.Fatalf("node info not found")
+	}
+	if got != info {
+		t.Errorf("expected %+v, got %+v", info, got)
+	}
+
+	list := s.Nodes()
+	if len(list) != 1 || list[0] != info {
+		t.Errorf("unexpected nodes list: %+v", list)
+	}
+}


### PR DESCRIPTION
## Summary
- clean up unused code in mqtt.go
- add tests for Store Add/Get and NodeInfo
- add tests for HTTP API handlers in server.go

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6876079d5d5483238bbf4f04e03b2e68