### PR TITLE
Handle all protobuf packets

### DIFF
--- a/internal/meshdump/mqtt.go
+++ b/internal/meshdump/mqtt.go
@@ -135,6 +135,12 @@ func decodeProto(store *Store, topic string, payload []byte) bool {
 						store.SetNodeInfo(info)
 						return true
 					}
+				case mpb.PortNum_TEXT_MESSAGE_APP, mpb.PortNum_TEXT_MESSAGE_COMPRESSED_APP:
+					log.Printf("mqtt: text from %s: %s", id, string(data.GetPayload()))
+					return true
+				default:
+					log.Printf("mqtt: packet from %s port=%s len=%d", id, data.GetPortnum().String(), len(data.GetPayload()))
+					return true
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- decode more protobuf port types in `decodeProto`
- log text messages and packet details rather than reporting an unknown payload

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68764c59599c83239ee7039983bc05e5