### PR TITLE
Add decoder for MQTT payloads

### DIFF
--- a/internal/meshdump/decode.go
+++ b/internal/meshdump/decode.go
@@ -1,0 +1,121 @@
+package meshdump
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	mpb "github.com/meshtastic/go/generated"
+	"google.golang.org/protobuf/proto"
+	pproto "meshdump/internal/proto"
+)
+
+// Decoded holds telemetry entries or node info extracted from a payload.
+type Decoded struct {
+	Telemetry []Telemetry
+	NodeInfo  *NodeInfo
+}
+
+// DecodeMessage attempts to decode an MQTT payload that may contain JSON or
+// protobuf encoded data. The topic is used to infer the node ID when missing.
+func DecodeMessage(topic, payload string) (*Decoded, error) {
+	trimmed := strings.TrimSpace(payload)
+	if strings.HasPrefix(trimmed, "{") {
+		if d, ok := decodeJSON(topic, []byte(trimmed)); ok {
+			return d, nil
+		}
+	}
+
+	raw := []byte(trimmed)
+	if b, err := base64.StdEncoding.DecodeString(trimmed); err == nil {
+		raw = b
+	}
+	if d, ok := decodeProtoMessage(topic, raw); ok {
+		return d, nil
+	}
+	return nil, fmt.Errorf("unknown payload format")
+}
+
+func decodeJSON(topic string, data []byte) (*Decoded, bool) {
+	var tel Telemetry
+	if err := json.Unmarshal(data, &tel); err == nil {
+		if tel.NodeID == "" {
+			if id, ok := nodeIDFromTopic(topic); ok {
+				tel.NodeID = id
+			}
+		}
+		if tel.NodeID != "" {
+			return &Decoded{Telemetry: []Telemetry{tel}}, true
+		}
+	}
+
+	var pos jsonPosition
+	if err := json.Unmarshal(data, &pos); err == nil && pos.Type == "position" {
+		id := strings.TrimPrefix(pos.Sender, "!")
+		if id == "" && pos.From != 0 {
+			id = fmt.Sprintf("%08x", pos.From)
+		}
+		if id == "" {
+			if tID, ok := nodeIDFromTopic(topic); ok {
+				id = tID
+			}
+		}
+		if id == "" {
+			return nil, false
+		}
+		ts := time.Now()
+		if pos.Payload.Time != 0 {
+			ts = time.Unix(pos.Payload.Time, 0)
+		} else if pos.Timestamp != 0 {
+			ts = time.Unix(pos.Timestamp, 0)
+		}
+		lat := float64(pos.Payload.LatitudeI) / 1e7
+		lon := float64(pos.Payload.LongitudeI) / 1e7
+		return &Decoded{Telemetry: []Telemetry{
+			{NodeID: id, DataType: "latitude", Value: lat, Timestamp: ts},
+			{NodeID: id, DataType: "longitude", Value: lon, Timestamp: ts},
+		}}, true
+	}
+
+	return nil, false
+}
+
+func decodeProtoMessage(topic string, payload []byte) (*Decoded, bool) {
+	var env mpb.ServiceEnvelope
+	if err := proto.Unmarshal(payload, &env); err == nil {
+		if pkt := env.GetPacket(); pkt != nil {
+			id := fmt.Sprintf("%08x", pkt.GetFrom())
+			if data := pkt.GetDecoded(); data != nil {
+				switch data.GetPortnum() {
+				case mpb.PortNum_TELEMETRY_APP:
+					var tm mpb.Telemetry
+					if err := proto.Unmarshal(data.GetPayload(), &tm); err == nil {
+						return &Decoded{Telemetry: telemetryFromProto(id, &tm)}, true
+					}
+				case mpb.PortNum_NODEINFO_APP:
+					var ni mpb.NodeInfo
+					if err := proto.Unmarshal(data.GetPayload(), &ni); err == nil {
+						info := NodeInfo{ID: fmt.Sprintf("%08x", ni.GetNum())}
+						if u := ni.GetUser(); u != nil {
+							info.LongName = u.GetLongName()
+							info.ShortName = u.GetShortName()
+						}
+						return &Decoded{NodeInfo: &info}, true
+					}
+				}
+			}
+		}
+	}
+
+	var mr pproto.MapReport
+	if err := proto.Unmarshal(payload, &mr); err == nil {
+		if id, ok := nodeIDFromTopic(topic); ok {
+			info := NodeInfo{ID: id, LongName: mr.GetLongName(), ShortName: mr.GetShortName(), Firmware: mr.GetFirmwareVersion()}
+			return &Decoded{NodeInfo: &info}, true
+		}
+	}
+
+	return nil, false
+}

--- a/internal/meshdump/decode_test.go
+++ b/internal/meshdump/decode_test.go
@@ -1,0 +1,58 @@
+package meshdump
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	mpb "github.com/meshtastic/go/generated"
+	"google.golang.org/protobuf/proto"
+	pproto "meshdump/internal/proto"
+)
+
+func TestDecodeMessageJSON(t *testing.T) {
+	tel := Telemetry{NodeID: "node1", DataType: "temperature", Value: 12.5}
+	data, _ := json.Marshal(tel)
+	dec, err := DecodeMessage("msh/node1", string(data))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(dec.Telemetry) != 1 || dec.Telemetry[0].NodeID != tel.NodeID {
+		t.Fatalf("unexpected telemetry: %+v", dec.Telemetry)
+	}
+}
+
+func TestDecodeMessageProto(t *testing.T) {
+	batt := uint32(50)
+	tm := &mpb.Telemetry{Time: 1000,
+		Variant: &mpb.Telemetry_DeviceMetrics{DeviceMetrics: &mpb.DeviceMetrics{BatteryLevel: &batt}},
+	}
+	tmData, _ := proto.Marshal(tm)
+	pkt := &mpb.MeshPacket{From: 1, PayloadVariant: &mpb.MeshPacket_Decoded{Decoded: &mpb.Data{Portnum: mpb.PortNum_TELEMETRY_APP, Payload: tmData}}}
+	env := &mpb.ServiceEnvelope{Packet: pkt}
+	raw, _ := proto.Marshal(env)
+	enc := base64.StdEncoding.EncodeToString(raw)
+	dec, err := DecodeMessage("msh/00000001", enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(dec.Telemetry) == 0 {
+		t.Fatalf("no telemetry decoded")
+	}
+	if dec.Telemetry[0].NodeID != "00000001" {
+		t.Errorf("unexpected node id: %s", dec.Telemetry[0].NodeID)
+	}
+}
+
+func TestDecodeMessageMapReport(t *testing.T) {
+	mr := &pproto.MapReport{LongName: "Node", FirmwareVersion: "1.0"}
+	raw, _ := proto.Marshal(mr)
+	enc := base64.StdEncoding.EncodeToString(raw)
+	dec, err := DecodeMessage("msh/nodeX", enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if dec.NodeInfo == nil || dec.NodeInfo.LongName != "Node" {
+		t.Fatalf("unexpected node info: %+v", dec.NodeInfo)
+	}
+}


### PR DESCRIPTION
## Summary
- add universal decoder for Meshtastic MQTT payloads
- refactor MQTT subscription to use the new decoder
- test protobuf, JSON, and MapReport decoding

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68764d89f6a88323bbcdca4aae16c150