### PR TITLE
Fix empty chart not showing

### DIFF
--- a/internal/meshdump/web/index.html
+++ b/internal/meshdump/web/index.html
@@ -96,6 +96,7 @@ async function refresh() {
 async function init() {
     const select = document.getElementById('nodeSelect');
     select.addEventListener('change', refresh);
+    ensureChart([]); // show an empty graph until data arrives
     const nodes = await updateNodes();
     if (nodes.length) {
         select.value = nodes[0].id;


### PR DESCRIPTION
## Summary
- always render a chart even when no nodes are available

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68765606c96c83238c7303509dcef1ce