### PR TITLE
Ensure node ID grouping and DB index

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ automatically and reloaded on startup so historical data is preserved across
 restarts.
 Node metadata now includes the firmware version when available.
 
+Each node is identified by a unique `node_id`. The SQLite database keeps all
+telemetry for a node grouped under this identifier. The `nodes` table uses
+`node_id` as its primary key and the `telemetry` table references it so that all
+measurements for the same node can be efficiently queried.
+
 Set `DEBUG=1` to print additional information, including the list of nodes and
 their names, to the terminal.
 

--- a/internal/meshdump/store.go
+++ b/internal/meshdump/store.go
@@ -137,18 +137,20 @@ func (s *Store) Node(id string) (NodeInfo, bool) {
 
 // initDB creates the required tables if they do not exist.
 func (s *Store) initDB() error {
-	schema := `CREATE TABLE IF NOT EXISTS telemetry (
-    node_id TEXT,
-    data_type TEXT,
-    value REAL,
-    timestamp TEXT
-);
-CREATE TABLE IF NOT EXISTS nodes (
+	schema := `CREATE TABLE IF NOT EXISTS nodes (
     node_id TEXT PRIMARY KEY,
     long_name TEXT,
     short_name TEXT,
     firmware TEXT
-);`
+);
+CREATE TABLE IF NOT EXISTS telemetry (
+    node_id TEXT NOT NULL,
+    data_type TEXT,
+    value REAL,
+    timestamp TEXT,
+    FOREIGN KEY(node_id) REFERENCES nodes(node_id)
+);
+CREATE INDEX IF NOT EXISTS idx_telemetry_node_id ON telemetry(node_id);`
 	if s.db == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- document that node_id uniquely identifies each node
- ensure the SQLite DB groups telemetry by node_id via a foreign key and index

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68765853284083239c541aeed574cc1a