### PR TITLE
Serve static libs, highlight nodes

### DIFF
--- a/internal/meshdump/server.go
+++ b/internal/meshdump/server.go
@@ -1,7 +1,7 @@
 package meshdump
 
 import (
-	_ "embed"
+	"embed"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -25,6 +25,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/api/telemetry/", s.handleTelemetry())
 	s.mux.HandleFunc("/api/nodes", s.handleNodes)
 	s.mux.HandleFunc("/api/nodeinfo/", s.handleNodeInfo())
+	s.mux.Handle("/lib/", http.StripPrefix("/lib/", http.FileServer(http.FS(libFS))))
 	s.mux.HandleFunc("/", s.handleIndex)
 }
 
@@ -82,6 +83,9 @@ func (s *Server) handleNodeInfo() http.HandlerFunc {
 
 //go:embed web/index.html
 var indexHTML string
+
+//go:embed web/lib/*
+var libFS embed.FS
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")

--- a/internal/meshdump/server_test.go
+++ b/internal/meshdump/server_test.go
@@ -61,7 +61,7 @@ func TestNodesHandler(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &nodes); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(nodes) != 1 || nodes[0].ID != exampleTelemetry.NodeID {
+	if len(nodes) != 1 || nodes[0].ID != exampleTelemetry.NodeID || !nodes[0].HasData {
 		t.Errorf("unexpected nodes: %v", nodes)
 	}
 }
@@ -81,7 +81,7 @@ func TestNodeInfoHandler(t *testing.T) {
 	}
 
 	stored, ok := st.Node(exampleTelemetry.NodeID)
-	if !ok || stored.LongName != "Tester" || stored.Firmware != "2.0" {
+	if !ok || stored.LongName != "Tester" || stored.Firmware != "2.0" || !stored.HasData {
 		t.Errorf("node info not stored: %+v", stored)
 	}
 
@@ -96,7 +96,7 @@ func TestNodeInfoHandler(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if got.ID != exampleTelemetry.NodeID || got.LongName != "Tester" {
+	if got.ID != exampleTelemetry.NodeID || got.LongName != "Tester" || !got.HasData {
 		t.Errorf("unexpected node info: %+v", got)
 	}
 }

--- a/internal/meshdump/web/index.html
+++ b/internal/meshdump/web/index.html
@@ -11,6 +11,7 @@
         #sidebar { margin-right: 20px; }
         #nodeSelect { min-width: 200px; padding: 4px; font-size: 14px; }
         #nodeList { list-style: none; padding-left: 0; margin-top: 10px; }
+        .has-data { font-weight: bold; }
     </style>
 </head>
 <body>
@@ -64,9 +65,11 @@ async function updateNodes() {
         const opt = document.createElement('option');
         opt.value = n.id;
         opt.textContent = name;
+        if (n.has_data) opt.classList.add('has-data');
         select.appendChild(opt);
         const li = document.createElement('li');
         li.textContent = name;
+        if (n.has_data) li.classList.add('has-data');
         list.appendChild(li);
     }
     if (current) {


### PR DESCRIPTION
## Summary
- serve Chart.js libraries from embedded assets
- keep node list order stable and mark nodes with telemetry
- highlight nodes that have data in the UI

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687663ee44608323af821fe36a4d8763