### PR TITLE
Add flexible build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ Both MQTT and store messages are matched by the regular expression used in the p
 
 ## Building
 
-Run `./build.sh` on a Linux machine with Docker installed. The script compiles
-a self-contained Windows binary named `MeshDump.exe` using a Go Docker image.
+Run `./build.sh [os] [arch]` on a Linux machine with Docker installed. The
+script compiles a binary for the specified target using a Go Docker image. For
+example `./build.sh linux amd64` builds a Linux binary named `MeshDump`, while
+`./build.sh windows amd64` produces `MeshDump.exe`.
 
 ## License
 

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,17 @@
 #!/bin/sh
 set -e
 
-echo "Building Windows binary using Docker..."
-docker run --rm -v "$PWD":/src -w /src golang:1.23 \
-    sh -c 'go mod tidy && \
-    GOOS=windows GOARCH=amd64 go build -buildvcs=false -o MeshDump.exe ./cmd/meshdump'
+OS=${1:-linux}
+ARCH=${2:-amd64}
 
-echo "Binary available at MeshDump.exe"
+output="MeshDump"
+if [ "$OS" = "windows" ]; then
+    output="MeshDump.exe"
+fi
+
+echo "Building $OS/$ARCH binary using Docker..."
+docker run --rm -v "$PWD":/src -w /src golang:1.23 \
+    sh -c "go mod tidy && \
+    GOOS=$OS GOARCH=$ARCH go build -buildvcs=false -o $output ./cmd/meshdump"
+
+echo "Binary available at $output"


### PR DESCRIPTION
## Summary
- make build.sh accept OS and architecture
- document how to build for arbitrary targets in README

## Testing
- `go test ./...`
- `./build.sh linux amd64` *(fails: `docker: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6876d6c5521c8323aca0cbe178dd1b3b