### PR TITLE
Add flexible build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ Both MQTT and store messages are matched by the regular expression used in the p
 
 ## Building
 
-Run `./build.sh` on a Linux machine with Docker installed. The script compiles
-a self-contained Windows binary named `MeshDump.exe` using a Go Docker image.
+Run `./build.sh [os] [arch]` on a Linux machine with Docker installed and the
+daemon running. The script compiles a binary for the specified target using a
+Go Docker image. For example `./build.sh windows amd64` builds
+`MeshDump.exe` for Windows. Passing `all` as the first argument builds both the
+Linux and Windows binaries for the given architecture in one go, e.g.
+`./build.sh all amd64`.
 
 ## License
 

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,29 @@
 #!/bin/sh
 set -e
 
-echo "Building Windows binary using Docker..."
-docker run --rm -v "$PWD":/src -w /src golang:1.23 \
-    sh -c 'go mod tidy && \
-    GOOS=windows GOARCH=amd64 go build -buildvcs=false -o MeshDump.exe ./cmd/meshdump'
+OS=${1:-linux}
+ARCH=${2:-amd64}
 
-echo "Binary available at MeshDump.exe"
+build() {
+    os=$1
+    arch=$2
+    output="MeshDump"
+    if [ "$os" = "windows" ]; then
+        output="MeshDump.exe"
+    fi
+
+    echo "Building $os/$arch binary using Docker..."
+    docker run --rm -v "$PWD":/src -w /src golang:1.23 \
+        sh -c "go mod tidy && \
+        GOOS=$os GOARCH=$arch go build -buildvcs=false -o $output ./cmd/meshdump"
+
+    echo "Binary available at $output"
+}
+
+if [ "$OS" = "all" ]; then
+    for os in linux windows; do
+        build "$os" "$ARCH"
+    done
+else
+    build "$OS" "$ARCH"
+fi


### PR DESCRIPTION
## Summary
- make build.sh accept OS and architecture
- build for multiple targets at once with `all`
- document how to build for arbitrary targets in README

## Testing
- `go test ./...`
- `./build.sh linux amd64` *(fails: `Cannot connect to the Docker daemon`)*

------
https://chatgpt.com/codex/tasks/task_e_6876d6c5521c8323aca0cbe178dd1b3b