### PR TITLE
Add debug logging for MQTT decode errors

### DIFF
--- a/internal/meshdump/mqtt.go
+++ b/internal/meshdump/mqtt.go
@@ -142,8 +142,16 @@ func StartMQTT(ctx context.Context, broker, topic, user, pass string, store *Sto
 	client.Publish("meshdump/welcome", 0, false, []byte("MeshDump connected"))
 
 	if t := client.Subscribe(topic, 0, func(c mqtt.Client, m mqtt.Message) {
-		dec, err := DecodeMessage(m.Topic(), string(m.Payload()))
+		payload := m.Payload()
+		dec, err := DecodeMessage(m.Topic(), string(payload))
 		if err != nil {
+			if store.debug {
+				b := payload
+				if len(b) > 200 {
+					b = append(b[:200], '.', '.', '.')
+				}
+				log.Printf("debug: decode failed topic=%s payload=%q err=%v", m.Topic(), b, err)
+			}
 			log.Printf("mqtt decode: %v", err)
 			return
 		}


### PR DESCRIPTION
## Summary
- improve MQTT decode error reporting when running in debug mode
- show failing topic and truncated payload

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876e458506c83239a09d2c45b00fc5b