### PR TITLE
Normalize node IDs from JSON payloads

### DIFF
--- a/internal/meshdump/decode.go
+++ b/internal/meshdump/decode.go
@@ -45,6 +45,8 @@ func decodeJSON(topic string, data []byte) (*Decoded, bool) {
 			if id, ok := nodeIDFromTopic(topic); ok {
 				tel.NodeID = id
 			}
+		} else {
+			tel.NodeID = strings.ToLower(tel.NodeID)
 		}
 		if tel.NodeID != "" {
 			return &Decoded{Telemetry: []Telemetry{tel}}, true
@@ -65,6 +67,7 @@ func decodeJSON(topic string, data []byte) (*Decoded, bool) {
 		if id == "" {
 			return nil, false
 		}
+		id = strings.ToLower(id)
 		ts := time.Now()
 		if pos.Payload.Time != 0 {
 			ts = time.Unix(pos.Payload.Time, 0)

--- a/internal/meshdump/decode_test.go
+++ b/internal/meshdump/decode_test.go
@@ -81,3 +81,14 @@ func TestDecodeMessageProtoPosition(t *testing.T) {
 		t.Errorf("unexpected node id: %s", dec.Telemetry[0].NodeID)
 	}
 }
+func TestDecodeMessageJSONUppercase(t *testing.T) {
+	tel := Telemetry{NodeID: "ABCDEF12", DataType: "temperature", Value: 1}
+	data, _ := json.Marshal(tel)
+	dec, err := DecodeMessage("msh/abcdef12", string(data))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if dec.Telemetry[0].NodeID != "abcdef12" {
+		t.Errorf("expected lowercase id, got %s", dec.Telemetry[0].NodeID)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize node IDs when decoding JSON messages
- test that JSON payloads with uppercase node IDs are normalized

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68776936b164832391b6badeb136945b