### PR TITLE
Enable auto commit of build outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Linux and Windows binaries for the given architecture in one go, e.g.
 `all` builds everything at once, including Raspberry Pi targets:
 `./build.sh all` or `./build.sh all all`.
 
+The script also commits the generated binaries to the Git repository
+and pushes them if a remote is configured.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,9 @@ minor=$((minor + 1))
 new_version="$major.$minor"
 echo "$new_version" > "$version_file"
 
+# track built binaries so we can commit them later
+built_files=""
+
 build() {
     os=$1
     arch=$2
@@ -44,6 +47,7 @@ build() {
 
     chmod +x "$output"
     echo "Binary available at $output"
+    built_files="$built_files $output"
 }
 
 if [ "$OS" = "all" ] && { [ "$ARCH" = "all" ] || [ -z "$2" ]; }; then
@@ -60,4 +64,13 @@ elif [ "$OS" = "rpi" ]; then
     build linux arm64 "$new_version"
 else
     build "$OS" "$ARCH" "$new_version"
+fi
+
+# automatically commit and push the built binaries and version file
+if [ -n "$built_files" ]; then
+    git add "$version_file" $built_files
+    git commit -m "Add compiled binaries for version $new_version"
+    if git remote | grep -q .; then
+        git push
+    fi
 fi


### PR DESCRIPTION
## Summary
- add automatic commit and push of binaries in `build.sh`
- document new build script behavior in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6877d08696048323a2d40c1e9d197a03