### PR TITLE
Enable auto commit of build outputs

### DIFF
--- a/.env
+++ b/.env
@@ -22,3 +22,7 @@ DATA_FILE=./telemetry.db
 
 # Enable extra logging when set to 1
 DEBUG=0
+
+# Git identity used for automatic commits in build.sh
+GIT_USER_NAME="MeshDump Builder"
+GIT_USER_EMAIL=builder@example.com

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ looks in the current working directory and then in the directory containing the
 executable. This lets you keep the configuration next to the binary when
 running it outside of the source tree.
 
+Two optional variables control the Git identity used by `build.sh` when
+committing build artifacts:
+
+```
+GIT_USER_NAME="MeshDump Builder"
+GIT_USER_EMAIL=builder@example.com
+```
+
 
 ## Parsing logs
 
@@ -75,8 +83,10 @@ Linux and Windows binaries for the given architecture in one go, e.g.
 
 The script also commits the generated binaries to the Git repository
 and pushes them if a remote is configured. If `user.name` or
-`user.email` are not configured locally, the script sets them to a
-default identity so the commit succeeds.
+`user.email` are not configured locally, the script sets them using the
+`GIT_USER_NAME` and `GIT_USER_EMAIL` environment variables (configured
+in `.env`). If those variables are absent, a default identity is used so
+the commit succeeds.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Linux and Windows binaries for the given architecture in one go, e.g.
 `all` builds everything at once, including Raspberry Pi targets:
 `./build.sh all` or `./build.sh all all`.
 
+The script also commits the generated binaries to the Git repository
+and pushes them if a remote is configured. If `user.name` or
+`user.email` are not configured locally, the script sets them to a
+default identity so the commit succeeds.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# load environment variables from .env if present
+if [ -f .env ]; then
+    # shellcheck disable=SC1091
+    . ./.env
+fi
+
 OS=${1:-linux}
 ARCH=${2:-amd64}
 
@@ -18,12 +24,15 @@ echo "$new_version" > "$version_file"
 # track built binaries so we can commit them later
 built_files=""
 
-# ensure git author identity is set
+# ensure git author identity is set using environment variables when available
+GIT_USER_EMAIL=${GIT_USER_EMAIL:-builder@example.com}
+GIT_USER_NAME=${GIT_USER_NAME:-MeshDump Builder}
+
 if ! git config user.email >/dev/null; then
-    git config user.email "builder@example.com"
+    git config user.email "$GIT_USER_EMAIL"
 fi
 if ! git config user.name >/dev/null; then
-    git config user.name "MeshDump Builder"
+    git config user.name "$GIT_USER_NAME"
 fi
 
 build() {


### PR DESCRIPTION
## Summary
- add default git identity to `build.sh`
- document new identity behavior in README

## Testing
- `shellcheck build.sh`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877d08696048323a2d40c1e9d197a03