### PR TITLE
Add git remote credentials via .env

### DIFF
--- a/.env
+++ b/.env
@@ -22,3 +22,12 @@ DATA_FILE=./telemetry.db
 
 # Enable extra logging when set to 1
 DEBUG=0
+
+# Git configuration used by build.sh when committing binaries
+GIT_USER_NAME="MeshDump Builder"
+GIT_USER_EMAIL=builder@example.com
+
+# Optional credentials for pushing to GitHub
+GITHUB_USER=your_username
+GITHUB_TOKEN=your_token
+REPOSITORY=your_repository

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ GIT_USER_NAME="MeshDump Builder"
 GIT_USER_EMAIL=builder@example.com
 ```
 
+Three more variables let `build.sh` push without prompting for credentials by
+configuring the Git remote automatically:
+
+```
+GITHUB_USER=your_username
+GITHUB_TOKEN=your_personal_token
+REPOSITORY=your_repository
+```
+
+When all three are set, the script sets the remote URL to
+`https://${GITHUB_TOKEN}@github.com/${GITHUB_USER}/${REPOSITORY}.git` before
+running `git push`.
+
 
 ## Parsing logs
 

--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,16 @@ if ! git config user.name >/dev/null; then
     git config user.name "$GIT_USER_NAME"
 fi
 
+# configure git remote using credentials from .env when available
+if [ -n "$GITHUB_USER" ] && [ -n "$GITHUB_TOKEN" ] && [ -n "$REPOSITORY" ]; then
+    remote_url="https://${GITHUB_TOKEN}@github.com/${GITHUB_USER}/${REPOSITORY}.git"
+    if git remote | grep -q origin; then
+        git remote set-url origin "$remote_url"
+    else
+        git remote add origin "$remote_url"
+    fi
+fi
+
 build() {
     os=$1
     arch=$2


### PR DESCRIPTION
## Summary
- add `GITHUB_USER`, `GITHUB_TOKEN` and `REPOSITORY` to `.env`
- update README with instructions about the new environment variables
- configure git remote in `build.sh` when credentials are present

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68783fb03ea88323b6e636c7f2e03a0b